### PR TITLE
Fix for debian9

### DIFF
--- a/rvm-ruby/init.sls
+++ b/rvm-ruby/init.sls
@@ -19,8 +19,7 @@ mri-deps:
     - pkgs:
       - build-essential
       - openssl
-      - libreadline6
-      - libreadline6-dev
+      - libreadline-dev
       - curl
       - git-core
       - zlib1g


### PR DESCRIPTION
Debian 9 (stretch) doesn't have libreadline6, it has libreadline7, however, installing libreadline-dev will install libreadline7 and libreadline7-dev, and it will install libreadline6 and libreadline6-dev in debian 7/8.